### PR TITLE
Update docker-and-vm.md

### DIFF
--- a/doc/docker-and-vm.md
+++ b/doc/docker-and-vm.md
@@ -7,7 +7,7 @@ In many situations the cache watcher "just works" when run inside the container.
 For example, if you are using [Warden](https://warden.dev), you can run the utility
 after running `warden shell`:
 ```
-$ composer global install mage2tv/magento-cache-clean
+$ composer global require mage2tv/magento-cache-clean
 $ ~/.composer/vendor/bin/cache-clean.js -w
 ```
 And since the composer directory is mounted in the image, the installation only has to


### PR DESCRIPTION
Using install vs require, I was getting following error message:
```
Invalid argument mage2tv/magento-cache-clean. Use "composer require mage2tv/magento-cache-clean" instead to add packages to your composer.json.
```