### PR TITLE
Cache clean fails with custom cache backend #111

### DIFF
--- a/src/cache/cache.cljs
+++ b/src/cache/cache.cljs
@@ -57,7 +57,9 @@
       (remote-synchronized/create (get-storage (remote-synchronized/extract-local-config config))
                                   (get-storage (remote-synchronized/extract-remote-config config)))
 
-      (file/create config))))
+      (if (seq (:server (:backend_options config)))
+        (redis/create config)
+        (file/create config)))))
 
 (defn- clean
   ([cache] (storage/clean-all cache))


### PR DESCRIPTION
If custom backend class isn't specified in existing "case" conditions and "server" option defined then fallback to redis cache instead of files cache.
The change was tested.